### PR TITLE
[nemesis-generator] fix: not all files shows code coverage

### DIFF
--- a/nemesis-generator/.coveragerc
+++ b/nemesis-generator/.coveragerc
@@ -1,2 +1,5 @@
 [run]
-source = generator,configuration_generator,node_configuration_generator
+include = 
+	generator/*.py
+	configuration_generator/*.py
+	node_configuration_generator/*.py


### PR DESCRIPTION
problem: not all the files in nemesis-generator shows in codecov report
solution: using the source in the .coveragerc combines the code coverage files.  Switch to using the include instead of source.