### PR TITLE
[nanowallet] fix: Trezor init unit test expectation

### DIFF
--- a/nanowallet/tests/specs/trezorService.spec.js
+++ b/nanowallet/tests/specs/trezorService.spec.js
@@ -50,7 +50,6 @@ describe('Trezor Service', () => {
                     email: 'maintainers@nem.io',
                     appUrl: 'https://www.nem.io',
                 },
-                debug: true,
                 coreMode: 'popup',
             });
         });


### PR DESCRIPTION
Problem: Notice a wrong exception in a unit test.
Solution: Removed the unused expectation