### PR TITLE
Nanowallet/fix unit test and explorer linting

### DIFF
--- a/explorer/frontend/.stylelintrc.json
+++ b/explorer/frontend/.stylelintrc.json
@@ -20,6 +20,8 @@
         "function-no-unknown": null,
         "scss/function-no-unknown": [true],
 
+        "import-notation": null,
+
         "selector-class-pattern": "^([a-z][a-z0-9]*)(-[a-z0-9]+)*((__([a-z][a-z0-9]*)(-[a-z0-9]+)*)?(--([a-z][a-z0-9]*)(-[a-z0-9]+)*)?)*$"
     }
 }


### PR DESCRIPTION
## Fix unit test expectation and explorer stylelint config

Two small, independent fixes that get the branch back to a green build (on amd64).

### 1. NanoWallet - Trezor init spec expectation

`tests/specs/trezorService.spec.js` asserted that `TrezorConnect.init()` is called with
`debug: true`, but `src/app/modules/trezor/trezor.service.js` has never passed that flag —
it only sends `manifest` and `coreMode: 'popup'`. The spec has been failing on a clean tree.

Removed the stale `debug: true` expectation so the spec matches the actual service config.
No production code changed: debug logging in TrezorConnect stays off, which is what we want
in shipped builds.

### 2. NEM Explorer — disable `import-notation` stylelint rule

`stylelint-config-standard` v29 enables `import-notation`, which requires the modern
`@import url("…")` / `@use` notation. Our SCSS partials use plain `@import "./colors";`
style, so `npm run lint` fails on every file under `src/styles/`.

Rewriting the partials to `@use` is a larger refactor (namespacing, forwarding), so for now
the rule is turned off in `explorer/frontend/.stylelintrc.json`, consistent with the other
rules we already disable there (`function-no-unknown`, …).